### PR TITLE
Updating the Russian translation

### DIFF
--- a/ru.json
+++ b/ru.json
@@ -52,8 +52,8 @@
     "lng_context_copy_callback_data": "Копировать данные обратного вызова",
     "lng_context_forward_selected_no_quote": "Переслать выделенное без автора",
     "lng_selected_forward_no_quote": "Переслать без автора",
-    "lng_context_forward_msg_old_selected": "Переслать выделенное (Классическая пересылка)",
-    "lng_selected_forward_emoji_classic": "📠(Классическая пересылка)",
+    "lng_context_forward_msg_old_selected": "Переслать выделенное (Классика)",
+    "lng_selected_forward_emoji_classic": "📠(Классика)",
 
     "lng_message_id": "ID сообщения: ",
 


### PR DESCRIPTION
My mistake - I specified too long title for the classic forwarding, which caused the naming to stop displaying at all. Changed it to a shorter and more appropriate variant